### PR TITLE
cargo: restrict files included in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MPL-2.0"
 categories = ["multimedia::images"]
 repository = "https://github.com/kornelski/avif-parse"
 readme = "README.md"
-include = ["README.md", "Cargo.toml", "LICENSE", "/src/*.rs", "avif_parse.h"]
+include = ["/README.md", "/Cargo.toml", "/LICENSE", "/src/*.rs", "/avif_parse.h"]
 keywords = ["demuxer", "image", "parser", "heif"]
 
 [lib]


### PR DESCRIPTION
Currently, the following files and directories are included in published crates:

```
av1-avif/
av1-avif/LICENSE
av1-avif/README.md
av1-avif/testFiles/
av1-avif/testFiles/Link-U/
av1-avif/testFiles/Link-U/README.md
```

This is because the `package.include` setting includes the `README.md` and `LICENSE` file without leading `/`, making it match against *any* files with those names.

This PR adds leading `/` to the files in the `package.include` setting. I have confirmed that the `av1-avif` directory and the contained `README.md` and `LICENSE` files are no longer included by cargo when running `cargo package`.